### PR TITLE
charger: allow home button to wake

### DIFF
--- a/healthd/healthd_mode_charger.cpp
+++ b/healthd/healthd_mode_charger.cpp
@@ -460,6 +460,11 @@ static void process_key(charger* charger, int code, int64_t now) {
                 kick_animation(charger->batt_anim);
             }
         }
+    } else {
+        if (key->pending) {
+            request_suspend(false);
+            kick_animation(charger->batt_anim);
+        }
     }
 
     key->pending = false;
@@ -467,6 +472,7 @@ static void process_key(charger* charger, int code, int64_t now) {
 
 static void handle_input_state(charger* charger, int64_t now) {
     process_key(charger, KEY_POWER, now);
+    process_key(charger, KEY_HOME, now);
 
     if (charger->next_key_check != -1 && now > charger->next_key_check)
         charger->next_key_check = -1;


### PR DESCRIPTION
    charger: allow home button to wake

    On certain devices (e.g. galaxysmtd), the user expects the physical
    home button to be able to wake the device as well as the power button.